### PR TITLE
fix: lesson1 てきすとの設定方法変更

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ const ul = document.getElementById('ul');
 const listItem = document.createElement('li');
 
 // liタグにテキストを挿入
-listItem.innerHTML = 'これです';
+listItem.textContent = 'これです';
+console.log(listItem);
 
 // ulの子要素としてliタグを挿入
-list.appendChild(listItem);
+ul.appendChild(listItem);


### PR DESCRIPTION
liタグへのテキストの設定方法をinnerHTML→textContenに修正